### PR TITLE
Updated API to use `&str` instead of `String` for most use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+
+## 1.0.2
+
+Several functions that accepted `String`s were updated to instead accept `&str` as that seems more ergonomic.
+Specifically:
+
+- `set_context` now accepts a &str instead of a String for it's context key
+- `tag now` accepts a &str instead of a String for it's context key
+- `when_context` now accepts a &str instead of a String for it's context key
+
+Removed now redundant functions that accepted `&str`s.
+Specifically:
+
+- `tag_str` is removed
+- `show_str` is removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "behold"
 build = "build.rs"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Josh Marlow <joshmarlow@gmail.com>"]
 license = "MIT"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Documentation
 =============
 API documentation is available [here](https://docs.rs/behold/).
 
-Changelog is available [here](Changelog.md).
+Changelog is available [here](CHANGELOG.md).
 
 Core Concepts
 =============

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Documentation
 =============
 API documentation is available [here](https://docs.rs/behold/).
 
+Changelog is available [here](Changelog.md).
+
 Core Concepts
 =============
 
@@ -26,7 +28,7 @@ Contextual Debugging
 `BEHOLD.show("testing".to_string())` will print "testing" to the screen.
 `BEHOLD.when(true).show("testing".to_string())` will print "testing" to the screen.
 `BEHOLD.when(false).show("testing".to_string())` will do nothing.
-`BEHOLD.when_context("key".to_string()).show("testing".to_string())` will print "testing" to the screen but only if the "testing" key has been set to `true` previously.
+`BEHOLD.when_context("key").show("testing".to_string())` will print "testing" to the screen but only if the "testing" key has been set to `true` previously.
 
 
 ```rust
@@ -45,7 +47,7 @@ fn f2(idx: usize) {
 
 fn f3(idx: usize) {
     // Do something hard to debug
-    behold().when_context(format!("f3-{}", idx)).show(format!("Hello from f3({})!", idx));
+    behold().when_context(format!("f3-{}", idx).as_str()).show(format!("Hello from f3({})!", idx));
 }
 
 fn main() {
@@ -55,7 +57,7 @@ fn main() {
         f2(i);
         f3(i);
         // Context is global
-        behold().set_context("f3-1".to_string(), true);
+        behold().set_context("f3-1", true);
     }
 }
 ```
@@ -86,7 +88,7 @@ extern crate behold;
 use behold::behold;
 
 fn main() {
-    behold().tag("yolo".to_string()).show("Hello world!".to_string());
+    behold().tag("yolo").show("Hello world!".to_string());
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,23 +27,23 @@ impl Behold {
     /// # Examples
     /// ```
     /// use behold::behold;
-    /// behold().when_context("do-it".to_string()).show("Hello world!".to_string())
+    /// behold().when_context("do-it").show("Hello world!".to_string())
     /// ```
     /// Will output nothing.
     /// ```
     /// use behold::behold;
-    /// behold().set_context("do-it".to_string(), true);
-    /// behold().when_context("do-it".to_string()).show("Hello world!".to_string())
+    /// behold().set_context("do-it", true);
+    /// behold().when_context("do-it").show("Hello world!".to_string())
     /// ```
     /// Will produce the output:
     /// ```ignore
     /// "Hello world!"
     /// ```
-    pub fn set_context(&self, key: String, value: bool) {
+    pub fn set_context(&self, key: &str, value: bool) {
         let context = (*self.context).lock();
 
         if let Ok(mut context) = context {
-            (*context).insert(key, value);
+            (*context).insert(key.to_string(), value);
         } else if let Err(err) = context {
             panic!(
                 "when_context called on an instance of Behold - mutex already acquired - {:?}!",
@@ -56,32 +56,18 @@ impl Behold {
     /// # Examples
     /// ```
     /// use behold::behold;
-    /// behold().tag("apples".to_string()).show("Hello world!".to_string());
+    /// behold().tag("apples").show("Hello world!".to_string());
     /// ```
     /// Will produce the output:
     /// ```ignore
     /// "Hello world!, apples"
     /// ```
-    pub fn tag(&self, tag: String) -> Self {
+    pub fn tag(&self, tag: &str) -> Self {
         Behold {
             context: self.context.clone(),
             speak_up: self.speak_up,
-            tag: Some(tag),
+            tag: Some(tag.to_string()),
         }
-    }
-
-    /// Behave just like ```tag``` but accepts a ```&str```
-    /// # Examples
-    /// ```
-    /// use behold::behold;
-    /// behold().tag_str(&"apples").show("Hello world!".to_string());
-    /// ```
-    /// Will produce the output:
-    /// ```ignore
-    /// "Hello world!, apples"
-    /// ```
-    pub fn tag_str(&self, tag: &str) -> Self {
-        self.tag(tag.to_string())
     }
 
     /// Produce a behold instance which can speak up or not, depending on the parameter
@@ -111,21 +97,21 @@ impl Behold {
     /// # Examples
     /// ```
     /// use behold::behold;
-    /// behold().when_context("do-it".to_string()).show("Hello world!".to_string())
+    /// behold().when_context("do-it").show("Hello world!".to_string())
     /// ```
     /// Will output nothing.
     /// ```
     /// use behold::behold;
-    /// behold().set_context("do-it".to_string(), true);
-    /// behold().when_context("do-it".to_string()).show("Hello world!".to_string())
+    /// behold().set_context("do-it", true);
+    /// behold().when_context("do-it").show("Hello world!".to_string())
     /// ```
     /// Will output
     /// ```ignore
     /// "Hello world!"
     /// ```
-    pub fn when_context(&self, key: String) -> Self {
+    pub fn when_context(&self, key: &str) -> Self {
         let speak_up = match (*self.context).lock() {
-            Ok(context) => (*context).get(&key).cloned().unwrap_or_default(),
+            Ok(context) => (*context).get(&key.to_string()).cloned().unwrap_or_default(),
             Err(err) => {
                 panic!(
                     "when_context called on an instance of Behold - mutex already acquired - {:?}!",
@@ -160,20 +146,6 @@ impl Behold {
         }
     }
 
-    /// Behave just like ```show``` but accepts a ```&str```
-    /// # Examples
-    /// ```
-    /// use behold::behold;
-    /// behold().show_str(&"Hello world!");
-    /// ```
-    /// Will produce the output:
-    /// ```ignore
-    /// "Hello world!"
-    /// ```
-    pub fn show_str(&self, msg: &str) {
-        self.show(msg.to_string())
-    }
-
     /// Call the provided function if this behold instance is configured to speak up
     /// # Examples
     /// ```
@@ -203,7 +175,7 @@ impl Behold {
 ///
 /// ```rust
 /// use behold::behold;
-/// behold().show_str("Hello world!");
+/// behold().show("Hello world!".to_string());
 /// ```
 /// Will produce the output:
 /// ```ignore


### PR DESCRIPTION
After more usage, I believe this is a more ergonomic interface.

I've also added a CHANGELOG to track this and subsequent changes.